### PR TITLE
Fix ClassCastException in getTimestamp(idx, calendar).

### DIFF
--- a/src/main/java/de/simplicit/vjdbc/serial/StreamingResultSet.java
+++ b/src/main/java/de/simplicit/vjdbc/serial/StreamingResultSet.java
@@ -1471,7 +1471,7 @@ public class StreamingResultSet implements ResultSet, Externalizable {
 		Timestamp timestamp = getTimestamp(columnIndex);
 		if(timestamp != null) {
 			cal.setTime(timestamp);
-			return (Timestamp)cal.getTime();
+			return new Timestamp(cal.getTime().getTime());
 		}
 		else {
 			return null;


### PR DESCRIPTION
Calling getTimestamp version which accepts Calendar as second argument results in ClassCastException.
(Original fix is in https://sourceforge.net/p/vjdbc/bugs/8/)